### PR TITLE
Fix comparison of AADEntitlementManagementAccessPackageAssignmentPolicy in New-M365DSCDeltaReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * AADGroup
   * Various timing-related fixes for new group
+* AADEntitlementManagementAccessPackageAssignmentPolicy
+  * Fixed comparison in New-M365DSCDeltaReport
 * AADTenantAppManagementPolicy
   * Fixed an issue when updating the resource.
   FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
@@ -227,6 +227,7 @@ function Get-TargetResource
         {
             foreach ($setting in $formattedRequestorSettings.allowedRequestors)
             {
+                $setting.Remove('description') | Out-Null
                 if (-not $setting.ContainsKey('odataType'))
                 {
                     $setting.Add('odataType', $setting.'@odata.type')


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes the comparison of AADEntitlementManagementAccessPackageAssignmentPolicy in New-M365DSCDeltaReport by removing the redundant description parameter in the formattedRequestorSettings as its already done for EscalationApprovers and PrimaryApprovers 
#### This Pull Request (PR) fixes the following issues
Fixes #7210

#### Task list


- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
